### PR TITLE
Update on line 176 balances[currentWinner]

### DIFF
--- a/L8-Denial-of-Service.md
+++ b/L8-Denial-of-Service.md
@@ -173,7 +173,7 @@ contract Good {
 
     function setCurrentAuctionPrice() public payable {
         require(msg.value > currentAuctionPrice, "Need to pay more than the currentAuctionPrice");
-        balances[currentWinner] += currentAuctionPrice;
+        balances[currentWinner] = msg.value;
         currentAuctionPrice = msg.value;
         currentWinner = msg.sender;
     }


### PR DESCRIPTION
I think we can map the balance of msg.sender to msg.value. So the mapping is more accurate. eg. balances[currentWinner] = msg.value;
This way the mapping of balance of msg.sender will always be the amount they send in ethers 
I apologise in advance if I was wrong